### PR TITLE
make pars work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,13 @@
 intake_sdmx: an intake plugin for SDMX data sources
 ======================================================
 
+(c) 2021 Dr. Leo
+
 `Source code @ Github <https://github.com/dr-leo/intake_sdmx/>`_ —
-`Authors <AUTHORS>`_
 
 **intake_sdmx** is an `Apache 2.0-licensed <LICENSE>`_ 
 `intake <http://intake.readthedocs.io>`_ plugin for SDMX-compliant data sources
-such as BIS, ECB, ESTAT, INSEE, ILO, UNDS, UNICEF and more. 
+such as BIS, ECB, ESTAT, INSEE, ILO, UN, UNICEF, World Bank and more. 
 **intake_sdmx** leverages `pandaSDMX <http://pandasdmx.readthedocs.io>`_.
 
 Quick start
@@ -19,7 +20,7 @@ Quick start
 Development status
 ===================
 
-As of April 2021, intake_sdmx is merely a proof of concept. It lacks key features such asdownloading datasets. 
+As of June 2021, most intended core features have been implemented, if hardly tested.
 
 Implemented features:
 =================
@@ -28,15 +29,23 @@ Implemented features:
   from data sources supported by pandaSDMX
 * each entry is a sub-catalog of dataflows provided by that data source. This works only
   for SDMXML-based data sources, but not for JSON-based ones (OECD, ABS etc.).
-* read() method downloads the dataflows and stores them as entries. Those are
-  not very useful, yet. They contain some metadata such as the dataflow_id anddescription,   
-  but access to datasets is not yet implemented.
-  
+* Dataflow entries are stored in a subcatalog
+  as a lazy dict, i.e. the actual
+  metadata (= DataStructureDefinition, CodeLIsts etc.) are 
+  downloaded only when
+  instantiating a data source for a particular Dataflow. 
+  Thus, even the human-readable description of a Dataflow is 
+  visible only after creating the data source. 
+  Thus, the list of dataflows cannot be searched by keywords. 
+  This feature should be added asap.
+* pass kwargs to a data source to specify a 
+  key (= dimension values), startPeriod and endPeriod.
+* download a dataset and return a pandas dataframe
   
 License
 -------
 
-Copyright 2014–2021, `pandaSDMX developers <AUTHORS>`_
+Copyright 2021, Dr. Leo
 
 Licensed under the Apache License, Version 2.0 (the “License”); you may not use
 these files except in compliance with the License. You may obtain a copy of the

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,5 @@
+import intake
+src=intake.open_sdmx_sources()
+ecb=src.ECB
+exr=ecb.EXR(FREQ='A', CURRENCY='USD')
+

--- a/intake_sdmx.py
+++ b/intake_sdmx.py
@@ -1,76 +1,87 @@
 """intake plugin for SDMX data sources"""
 
 
-
 import intake
 from intake.catalog import Catalog
 from intake.catalog.local import LocalCatalogEntry, UserParameter
 import pandasdmx as sdmx
 from collections.abc import MutableMapping
+from datetime import date
 
-__version__ = '0.0.2'
-
+__version__ = "0.0.3"
 
 class LazyDict(MutableMapping):
     def __init__(self, func, *args, **kwargs):
         super().__init__()
         self._dict = dict(*args, **kwargs)
         self._func = func
-        
+
     def __getitem__(self, key):
         if self._dict[key] is None:
-            self._dict[key] = self._func(key) 
+            self._dict[key] = self._func(key)
         return self._dict[key]
-        
+
     def __setitem__(self, key, value):
         return self._dict.__setitem__(key, value)
-            
+
     def __len__(self):
         return self._dict.__len__()
 
     def __delitem__(self, key):
         return self._dict.__delitem__(key)
-        
+
     def __iter__(self):
         return self._dict.__iter__()
-    
+
     def __str__(self):
-        return ''.join((self.__class__.__name__, '(', str(self._dict), ')'))
-    
-    
+        return "".join((self.__class__.__name__, "(", str(self._dict), ")"))
+
+
 class SDMXSources(Catalog):
-    '''
+    """
      catalog of SDMX data sources, a.k.a. agencies 
     supported by pandaSDMX
-    '''
-    name = 'sdmx_sources'
-    description='SDMX sources supported by pandaSDMX' 
-    metadata=None
-    ttl=999999 
-    getenv=False 
-    getshell=False 
-    persist_mode='default' 
+    """
+
+    name = "sdmx_sources"
+    description = "SDMX sources supported by pandaSDMX"
+    metadata = None
+    ttl = 999999
+    getenv = False
+    getshell = False
+    persist_mode = "default"
     version = __version__
-    container = 'catalog'
+    container = "catalog"
     partition_access = False
-    
+
     def __init__(self, *args, **kwargs):
         super(SDMXSources, self).__init__(*args, **kwargs)
-        # populate this catalog with empty sub-catalogs for each source. 
-        # This does not require remote access. 
+        # populate this catalog with empty sub-catalogs for each source.
+        # This does not require remote access.
         # Sub-catalogs can read  the dataflows provided by each source.
-        # exclude sources which do not support dataflows 
+        # exclude sources which do not support dataflows
         # and datasets (eg json-based ABS and OECD)
-        excluded = ['ABS', 'OECD', 'IMF', 'SGR', 'STAT_EE']         
+        excluded = ["ABS", "OECD", "IMF", "SGR", "STAT_EE"]
         for source_id, source in sdmx.source.sources.items():
             if source_id not in excluded:
                 descr = source.name
-                metadata = {'source_id' : source_id}
-                e = LocalCatalogEntry(source_id, descr, SDMXDataflows, direct_access=True, 
+                metadata = {"source_id": source_id}
+                e = LocalCatalogEntry(
+                    source_id,
+                    descr,
+                    SDMXDataflows,
+                    direct_access=True,
                     args={},
-                     cache=[], parameters=[], metadata=metadata, catalog_dir='',
-                     getenv=False, getshell=False, catalog=self)
+                    cache=[],
+                    parameters=[],
+                    metadata=metadata,
+                    catalog_dir="",
+                    getenv=False,
+                    getshell=False,
+                    catalog=self,
+                )
                 self._entries[source_id] = e
+
 
 class SDMXCodeParam(UserParameter):
     def __init__(self, allowed=None, **kwargs):
@@ -79,42 +90,49 @@ class SDMXCodeParam(UserParameter):
 
     def validate(self, value):
         # Convert short-form multiple selections to list, e.g. 'DE+FR'
-        if isinstance(value, str) and '+' in value:
-            value = value.split('+')
-        # Make allowed codes as list, 
+        if isinstance(value, str) and "+" in value:
+            value = value.split("+")
+        # convert  allowed codes to  list,
         # i.e. extract the key from each dict
-        allowed_codes = [next(iter(c)) for c in self.allowed]        
+        allowed_codes = [next(iter(c)) for c in self.allowed]
         # Single code as str
-        if isinstance(value, str): 
-            if (value not in allowed_codes):
-                raise ValueError('%s=%s is not one of the allowed values: %s' % (
-                    self.name, value, ','.join(map(str, self.allowed))))
+        if isinstance(value, str):
+            if value not in allowed_codes:
+                raise ValueError(
+                    "%s=%s is not one of the allowed values: %s"
+                    % (self.name, value, ",".join(map(str, self.allowed)))
+                )
         # So value must be an  iterable  of str, e.g. multiple selection
-        elif not all(c in allowed_codes for c in value): 
-            not_allowed = [c for c in value if c not in  allowed_codes]
-            raise ValueError('%s=%s is not one of the allowed values: %s' % (
-            self.name, not_allowed, ','.join(map(str, self.allowed))))
+        elif not all(c in allowed_codes for c in value):
+            not_allowed = [c for c in value if c not in allowed_codes]
+            raise ValueError(
+                "%s=%s is not one of the allowed values: %s"
+                % (self.name, not_allowed, ",".join(map(str, self.allowed)))
+            )
         return value
 
+
 class SDMXDataflows(Catalog):
-    '''
+    """
      catalog of dataflows for a given SDMX source
-    '''
+    """
+
     version = __version__
-    container = 'catalog'
+    container = "catalog"
     partition_access = False
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._entries = LazyDict(self._make_dataflow_entry)
-        
+
         # read metadata on dataflows
-        self.name = self.metadata['source_id'] + '_SDMX_dataflows'
+        self.name = self.metadata["source_id"] + "_SDMX_dataflows"
         # Request dataflows from remote SDMX service
-        self.req = sdmx.Request(self.metadata['source_id'])
+        self.req = sdmx.Request(self.metadata["source_id"])
         # get full list of dataflows
         self._flows_msg = self.req.dataflow()
-        for  flow_id in self._flows_msg.dataflow:
-            self._entries[flow_id] = None  
+        for flow_id in self._flows_msg.dataflow:
+            self._entries[flow_id] = None
 
     def _make_dataflow_entry(self, flow_id):
         # Download metadata on specified dataflow
@@ -123,13 +141,14 @@ class SDMXDataflows(Catalog):
         dsd = flow.structure
         descr = flow.name.en
         metadata = self.metadata.copy()
-        metadata['dataflow_id'] = flow_id
-        metadata['structure_id'] = dsd.id
+        metadata["dataflow_id"] = flow_id
+        metadata["structure_id"] = dsd.id
         # Make user params for coded dimensions
         # Check for any content constraints to codelists
-        if hasattr(flow_msg, 'constraint') and flow_msg.constraint:
-            constraint = next(iter(flow_msg.constraint.
-                values())).data_content_region[0].member
+        if hasattr(flow_msg, "constraint") and flow_msg.constraint:
+            constraint = (
+                next(iter(flow_msg.constraint.values())).data_content_region[0].member
+            )
         else:
             constraint = None
         params = []
@@ -139,45 +158,79 @@ class SDMXDataflows(Catalog):
             # only dimensions with enumeration, i.e. where values are codes
             if lr.enumerated:
                 ci = dim.concept_identity
-                # Get code ID and English name as its description
+                # Get code ID and  name as its description
                 if constraint and dim.id in constraint:
-                    codes = [{c.id : c.name.en} for c in lr.enumerated.items.values() if c in constraint[dim.id]]
+                    codes = [
+                        {c.id: str(c.name)}
+                        for c in lr.enumerated.items.values()
+                        if c in constraint[dim.id]
+                    ]
                 else:
-                    codes = [{c.id : c.name.en} for c in lr.enumerated.items.values()]
+                    codes = [{c.id: str(c.name)} for c in lr.enumerated.items.values()]
+                # allow also "" to indicate wild-carded dimension
+                codes.append({"": "wild-carded"})
                 p = SDMXCodeParam(
                     name=dim.id,
-                    description=ci.name.en,
+                    description=str(ci.name),
                     type="str",
                     allowed=codes,
-# set first code as default                    
-                    default=next(iter(codes[0])))
+                    # set  default to "", ie. wild-card dimension
+                    default="",
+                )
                 params.append(p)
+        #  params for startPeriod and endPeriod
+        year = date.today().year
+        params.extend(
+            [
+                UserParameter(
+                    name="startPeriod",
+                    description="startPeriod",
+                    type="datetime",
+                    default=str(year - 1),
+                ),
+                UserParameter(
+                    name="endPeriod",
+                    description="endPeriod",
+                    type="datetime",
+                    default=str(year),
+                ),
+            ]
+        )
+        args = {p.name: f"{{{{{p.name}}}}}" for p in params}
+        return LocalCatalogEntry(
+            name=flow_id,
+            description=descr,
+            driver=SDMXData,
+            direct_access=True,
+            cache=[],
+            parameters=params,
+            args=args,
+            metadata=metadata,
+            catalog_dir="",
+            getenv=False,
+            getshell=False,
+            catalog=self,
+        )
 
-        args = {p.name: "{{%s}}" % p.name for p in params}
-        return LocalCatalogEntry(name=flow_id, description=descr, driver=SDMXData, direct_access=True, 
-             cache=[], parameters=params, args=args,
-             metadata=metadata, catalog_dir='',
-             getenv=False, getshell=False, catalog=self)
-                 
 
 class SDMXData(intake.source.base.DataSource):
-    '''
+    """
     Driver for SDMX data sets of  a given SDMX dataflow
-    '''
+    """
+
     version = __version__
-    name = 'sdmx_dataset'
-    container = 'dataframe'
+    name = "sdmx_dataset"
+    container = "dataframe"
     partition_access = True
 
     def __init__(self, metadata=None, **kwargs):
         super(SDMXData, self).__init__(metadata=metadata)
-        name = self.metadata['dataflow_id']
+        name = self.metadata["dataflow_id"]
         self.name = name
         self.kwargs = kwargs
-    
+
     def read(self):
-        name = self.metadata['dataflow_id'] + '_resources'
-    
+        name = self.metadata["dataflow_id"] + "_resources"
+
     def _close(self):
         self._dataframe = None
-    

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -1,26 +1,26 @@
 import intake
 import intake_sdmx
+import pytest
 
-
-
-def test_drivers():
+def test_ECB_EXR():
     sources = intake.open_sdmx_sources()
     assert isinstance(sources, intake_sdmx.SDMXSources)
-    ecb_cat = sources.ECB
-    assert isinstance(ecb_cat, intake_sdmx.SDMXDataflows)
-    # download the dataflow definitions from ECB
-    ecb_cat.read()
+    ecb = sources.ECB
+    assert isinstance(ecb, intake_sdmx.SDMXDataflows)
     # pick the dataflow for exchange rates
-    exr = ecb_cat.EXR
+    exr = ecb.EXR
     assert isinstance(exr, intake_sdmx.SDMXData)
     assert exr.name == "EXR"
     assert exr.description == "Exchange Rates"
-# TODO: _get_schema, read, discover etc.    
+    # check default values
+    assert exr.kwargs['FREQ'] == ''
+    # new instance with valid arg
+    exr2 = exr(FREQ='A')
+    assert exr2.kwargs['FREQ'] == 'A'
+    # new instance with invalid arg
+    with pytest.raises(ValueError):
+        exr3 = exr(FREQ='invalid')
     
     
-    
-    
-    
-    
-    
-    
+
+

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -2,6 +2,7 @@ import intake
 import intake_sdmx
 import pytest
 
+
 def test_ECB_EXR():
     sources = intake.open_sdmx_sources()
     assert isinstance(sources, intake_sdmx.SDMXSources)
@@ -13,14 +14,10 @@ def test_ECB_EXR():
     assert exr.name == "EXR"
     assert exr.description == "Exchange Rates"
     # check default values
-    assert exr.kwargs['FREQ'] == ''
+    assert exr.kwargs["FREQ"] == ""
     # new instance with valid arg
-    exr2 = exr(FREQ='A')
-    assert exr2.kwargs['FREQ'] == 'A'
+    exr2 = exr(FREQ="A")
+    assert exr2.kwargs["FREQ"] == "A"
     # new instance with invalid arg
     with pytest.raises(ValueError):
-        exr3 = exr(FREQ='invalid')
-    
-    
-
-
+        exr3 = exr(FREQ="invalid")


### PR DESCRIPTION
This does suggest that handling user_parameters in intake leaves something to be desired.

There are two things:
- you need to include the user parameter names in the argument list for the entry. User parameters can also be used within string templates, so they don't necessarily refer to arguments to be passed to the data source
- the required type is string (is this always true?), so the dictionary of values to enable rich descriptions was being converted into a string like '[{"CODE": "full name"}, ...]', which obviously didn't even match the default string
- Intake doesn't handle an "other" type for the user parameters, but it should. For that case, coersion should be a no-op.

```python
import intake_sdmx
cat = intake_sdmx.SDMXSources()
cat2 = cat.NB
s = cat2.IR # all default values
s2 = s(UNIT_MEASURE='ANN') # override on argument
s2 = cat2.IR(UNIT_MEASURE='ANN') # same effect as line above
```